### PR TITLE
Provide default path to chromium on Linux

### DIFF
--- a/packages/galata/bin/cli.js
+++ b/packages/galata/bin/cli.js
@@ -138,10 +138,16 @@ const cli = meow(`
         },
         chromePath: {
             type: 'string',
-            default: config.chromePath ||
-                (os.platform() == 'win32' ?
-                    'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe' :
-                    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')
+            default: config.chromePath || ((() => {
+                const platform = os.platform();
+                if (platform === 'win32') {
+                    return 'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe';
+                } else if (platform === 'linux') {
+                    return '/usr/bin/chromium';
+                } else {
+                    return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+                }
+            })())
         },
         chromeUrl: {
             type: 'string',


### PR DESCRIPTION
Partially addresses #1, by providing a default path to Chromium.

On Ubuntu 20.04 with Chromium installed via the snap store, this points to `/usr/bin/chromium`.

We might still want to revisit this later on, to handle CI cases (#3)