### PR TITLE
Add link to the Jupyter Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ Examples
     $ galata --update-references 2020-08-22_14-01-30
 ```
 
+## Community Guidelines and Code of Conduct
+
+This repository is a Jupyter project and follows the Jupyter
+[Community Guides and Code of Conduct](https://jupyter.readthedocs.io/en/latest/community/content-community.html).
+
 ## About Galata Name
 Galata framework is named after [Galata Tower](https://en.wikipedia.org/wiki/Galata_Tower) in Istanbul. Centuries ago, Galata Tower was used to spot fires in the city. Tower was also used as astronomical observatory in the past.
 


### PR DESCRIPTION
Add a link to the Jupyter Code of Conduct now that the repo has been moved to the `jupyterlab` organization on GitHub.