### PR TITLE
Rename report.html to index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Notes:
 
 - **--open-report**: Open result report
 
-    If set to true, opens the test result report URL at `http://localhost:8080/report/report.html` using system's default browser. Only has effect when `--result-server` is toggled. Can be negated using `--no-open-report`.
+    If set to true, opens the test result report URL at `http://localhost:8080/report/index.html` using system's default browser. Only has effect when `--result-server` is toggled. Can be negated using `--no-open-report`.
 
     *Default*: `true`
 

--- a/packages/galata/bin/cli.js
+++ b/packages/galata/bin/cli.js
@@ -355,7 +355,7 @@ function generateHTMLReport(testId) {
     const template = fs.readFileSync(path.resolve(__dirname, '../report.ejs'), 'utf-8');
     const html = ejs.render(template, { data: data });
 
-    fs.writeFileSync(path.join(testOutputDir, 'report/report.html'), html);
+    fs.writeFileSync(path.join(testOutputDir, 'report/index.html'), html);
 }
 
 function launchResultServer(testId) {
@@ -384,7 +384,7 @@ function launchResultServer(testId) {
     });
 
     if (cli.flags.openReport) {
-        open(`http://127.0.0.1:${port}/report/report.html`);
+        open(`http://127.0.0.1:${port}/report/index.html`);
     }
 }
 


### PR DESCRIPTION
So it's easier to server the folder with a web server, without having to specify the full path to `report.html`.