### PR TITLE
add theme API & configuration

### DIFF
--- a/packages/galata/bin/cli.js
+++ b/packages/galata/bin/cli.js
@@ -55,6 +55,7 @@ const cli = meow(`
       --open-report               open result report
       --image-match-threshold     image matching threshold
       --slow-mo                   slow down UI operations by the specified ms
+      --theme                     JupyterLab Theme to set [light / JupyterLab Light, dark / JupyterLab Dark, installed theme name]
 
     Other options:
       --launch-result-server      launch result file server for a test
@@ -176,6 +177,10 @@ const cli = meow(`
             type: 'string',
              // inside node_modules of client
             default: config.jestPath || './node_modules/.bin/jest'
+        },
+        theme: {
+            type: 'string',
+            default: config.theme || ''
         }
     }
 });

--- a/packages/galata/jest-env.js
+++ b/packages/galata/jest-env.js
@@ -119,6 +119,17 @@ class TestEnvironment extends NodeEnvironment {
         if (!sessionInfo.runtimeJlabVersion) {
             await checkJupyterLabVersion(context.page);
         }
+
+        if (config.theme !== '') {
+            const themeName = config.theme === 'dark' ? 'JupyterLab Dark' :
+                config.theme === 'light' ? 'JupyterLab Light' : config.theme;
+
+            log('info', `Setting theme to ${themeName}`, { save: false });
+
+            await context.page.evaluate(async (themeName) => {
+                await window.galataip.setTheme(themeName);
+            }, themeName);
+        }
     }
 
     async createNewPage(options) {

--- a/packages/galata/src/galata.ts
+++ b/packages/galata/src/galata.ts
@@ -1475,6 +1475,33 @@ namespace galata {
     }
 
     export
+    namespace theme {
+        export
+        async function setDarkTheme() {
+            await setTheme('JupyterLab Dark');
+        }
+
+        export
+        async function setLightTheme() {
+            await setTheme('JupyterLab Light');
+        }
+
+        export
+        async function getTheme(): Promise<string> {
+            return await context.page.evaluate(() => {
+                return document.body.dataset.jpThemeName;
+            });
+        }
+
+        export
+        async function setTheme(themeName: string) {
+            await context.page.evaluate(async (themeName: string) => {
+                await window.galataip.setTheme(themeName);
+            }, themeName);
+        }
+    }
+
+    export
     async function resetUI() {
         // close menus
         await menu.closeAll();

--- a/packages/galata/src/inpage/tokens.ts
+++ b/packages/galata/src/inpage/tokens.ts
@@ -54,6 +54,7 @@ interface IGalataInpage {
     isElementVisible(el: HTMLElement): boolean;
     waitForSelector(selector: string, node?: Element, options?: IWaitForSelectorOptions): Promise<Node | void>;
     waitForXPath(selector: string, node?: Element, options?: IWaitForSelectorOptions): Promise<Node | void>;
+    setTheme(themeName: string): Promise<void>;
 
     readonly app: JupyterFrontEnd;
 }

--- a/packages/galata/util.js
+++ b/packages/galata/util.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const path = require('path');
 
 const configKeys = {
-    "string": new Set(["browserType", "browserPath", "browserUrl", "jlabBaseUrl", "jlabToken", "testId", "testOutputDir", "referenceDir"]),
+    "string": new Set(["browserType", "browserPath", "browserUrl", "jlabBaseUrl", "jlabToken", "testId", "testOutputDir", "referenceDir", "theme"]),
     "boolean": new Set(["headless", "skipVisualRegression", "skipHtmlRegression", "discardMatchedCaptures"]),
     "int": new Set(["pageWidth", "pageHeight", "slowMo"]),
     "float": new Set(["imageMatchThreshold"]),


### PR DESCRIPTION
- allows setting theme from CLI with `--theme` option. Examples: `--theme dark` (same as `--theme "JupyterLab Dark"), --theme light` (same as `--theme "JupyterLab Light"`)
- adds `theme` namespace to API with functions to interact with theme

fixes https://github.com/jupyterlab/galata/issues/30