### PR TITLE
Enhancements to handle end-to-end JupyterLab UI testing

### DIFF
--- a/packages/galata/jest-env.js
+++ b/packages/galata/jest-env.js
@@ -33,9 +33,9 @@ async function checkJupyterLabVersion(page) {
         return window.galataip.app.version;
     });
 
-    if (semver.valid(runtimeJlabVersion)) {
-        const type = semver.major(runtimeJlabVersion) !== semver.major(buildJlabVersion) ? 'error' :
-            semver.minor(runtimeJlabVersion) !== semver.minor(buildJlabVersion) ? 'warning' : '';
+    if (semver.valid(runtimeJlabVersion, true)) {
+        const type = semver.major(runtimeJlabVersion, true) !== semver.major(buildJlabVersion, true) ? 'error' :
+            semver.minor(runtimeJlabVersion, true) !== semver.minor(buildJlabVersion, true) ? 'warning' : '';
 
         if (type === 'error' || type === 'warning') {
             log(type, `Run-time JupyterLab version (${runtimeJlabVersion}) is different than testing framework is built for (${buildJlabVersion}). This could cause issues in testing.`);

--- a/packages/galata/src/galata.ts
+++ b/packages/galata/src/galata.ts
@@ -97,7 +97,7 @@ namespace galata {
     type SidebarPosition = 'left' | 'right';
 
     export
-    type SidebarTabId = 'filebrowser' | 'jp-running-sessions' | 'tab-manager' | 'jp-property-inspector' | 'extensionmanager.main-view' | 'jp-debugger-sidebar';
+    type SidebarTabId = 'filebrowser' | 'jp-running-sessions' | 'tab-manager' | 'jp-property-inspector' | 'table-of-contents' | 'extensionmanager.main-view' | 'jp-debugger-sidebar';
 
     export
     function xpContainsClass(className: string): string {

--- a/packages/galata/src/galata.ts
+++ b/packages/galata/src/galata.ts
@@ -1518,6 +1518,30 @@ namespace galata {
         // go to home folder
         await filebrowser.openHomeDirectory();
     }
+
+    export
+    async function isInSimpleMode(): Promise<boolean> {
+        const toggle = await context.page.$('#jp-single-document-mode button.jp-switch');
+        const checked = await toggle.getAttribute('aria-checked') === 'true';
+
+        return checked;
+    }
+
+    export
+    async function toggleSimpleMode(simple: boolean): Promise<boolean> {
+        const toggle = await context.page.$('#jp-single-document-mode button.jp-switch');
+        const checked = await toggle.getAttribute('aria-checked') === 'true';
+
+        if ((checked && !simple) || (!checked && simple)) {
+            toggle.click();
+        }
+
+        await waitFor(async () => {
+            return await isInSimpleMode() === simple;
+        });
+
+        return true;
+    }
 };
 
 export { describeWrapper as describe, testWrapper as test };

--- a/packages/galata/src/galata.ts
+++ b/packages/galata/src/galata.ts
@@ -552,6 +552,16 @@ namespace galata {
         }
 
         export
+        async function getOpenMenu(): Promise<ElementHandle<Element> | null> {
+            const openMenus = await context.page.$$('.lm-Widget.lm-Menu .lm-Menu-content');
+            if (openMenus.length > 0) {
+                return openMenus[openMenus.length - 1];
+            }
+
+            return null;
+        }
+
+        export
         async function clickMenuItem(path: string) {
             const parts = path.split('>');
             const numParts = parts.length;

--- a/packages/galata/src/galata.ts
+++ b/packages/galata/src/galata.ts
@@ -94,7 +94,7 @@ namespace galata {
     const context: IGalataContext = global.__TEST_CONTEXT__;
 
     export
-    type SidebarTabId = 'filebrowser' | 'jp-running-sessions' | 'command-palette' | 'tab-manager';
+    type SidebarTabId = 'filebrowser' | 'jp-running-sessions' | 'tab-manager' | 'jp-property-inspector' | 'extensionmanager.main-view' | 'jp-debugger-sidebar';
 
     export
     function xpContainsClass(className: string): string {


### PR DESCRIPTION
- support new sidebar tabs of jlab 3
- support sidebar on right
- API to toggle Simple Mode
- API to get last opened menu
- fix for preRelease version comparison