### PR TITLE
Move the debugger sidebar to the left in moveAllTabsToLeft

### DIFF
--- a/packages/galata/src/galata.ts
+++ b/packages/galata/src/galata.ts
@@ -1800,8 +1800,9 @@ namespace galata {
                 for (let widgetId of Object.keys(overrides)) {
                     overrides[widgetId] = 'left';
                 }
-                // default location of property inspector is right, move it to left during tests
+                // default location of the property inspector and debugger is right, move it to left during tests
                 overrides["jp-property-inspector"] = "left";
+                overrides["jp-debugger-sidebar"] = "left";
                 await settingRegistry.set(SIDEBAR_ID, 'overrides', overrides);
             }, {pluginId: PLUGIN_ID_SETTINGS as keyof IPluginNameToInterfaceMap});
 


### PR DESCRIPTION
When the debugger sidebar (or other panels added to the right) is available, it looks like the `moveAllTabsToLeft` function times out when trying to move all the tabs to the left:

https://github.com/jupyterlab/galata/blob/d717e6a95f738679eaec86f1e5d799458ff584c4/packages/galata/src/galata.ts#L1795-L1812

This change adds `jp-debugger-sidebar` to the list of overrides to move to the left.