### PR TITLE
Update to 3.0.7-7

### DIFF
--- a/packages/galata-example/package.json
+++ b/packages/galata-example/package.json
@@ -9,6 +9,6 @@
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@jupyterlab/galata": "3.0.7-6"
+    "@jupyterlab/galata": "3.0.7-7"
   }
 }

--- a/packages/galata/package.json
+++ b/packages/galata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/galata",
-  "version": "3.0.7-6",
+  "version": "3.0.7-7",
   "description": "JupyterLab UI Testing Framework",
   "homepage": "https://github.com/jupyterlab/galata",
   "bugs": {


### PR DESCRIPTION
Update to `3.0.7-7` to cut a new release of Galata.