### PR TITLE
Update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,14 +9,14 @@
 2. Re-install dependencies and rebuild.
 
 ```
-lerna bootstrap --hoist
-lerna run build
+jlpm
+jlpm run build
 ```
 
 3. Run tests and make sure that all pass. Before running tests, JupyterLab must be up and running. You can use the launch command described in `Launch JupyterLab` section of [README.md](README.md#launch-jupyterlab)
 
 ```
-lerna run test --stream
+jlpm run test
 ```
 
 4. Commit your version changes.


### PR DESCRIPTION
Follow-up to #50 

Update release instructions to use `jlpm` for the commands.