### PR TITLE
Add jlpm build step to readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ cd galata/packages/galata-example
 # install dependencies
 jlpm
 
+# build
+jlpm run build 
+
 # run test suites using `test` script which calls `galata` CLI script
 jlpm run test
 ```


### PR DESCRIPTION
Add `jlpm run build` to the top part of the README. If this step is skipped, the user will get errors trying to run Galata.