### PR TITLE
Make generateWorkspace configurable via the CLI

### DIFF
--- a/packages/galata/bin/cli.js
+++ b/packages/galata/bin/cli.js
@@ -40,6 +40,7 @@ const cli = meow(
       --test-path-pattern         regexp pattern to match test files
       --jlab-base-url             JupyterLab base URL
       --jlab-token                JupyterLab authentication token
+      --generate-workspace        Whether to generate a new workspace for the session
       --jest-config               jest configuration file
       --jest-path                 jest executable path
       --headless                  flag to enable browser headless mode
@@ -83,6 +84,10 @@ const cli = meow(
       jlabToken: {
         type: 'string',
         default: config.jlabToken || ''
+      },
+      generateWorkspace: {
+        type: 'boolean',
+        default: true
       },
       headless: {
         type: 'boolean',

--- a/packages/galata/bin/cli.js
+++ b/packages/galata/bin/cli.js
@@ -87,7 +87,7 @@ const cli = meow(
       },
       generateWorkspace: {
         type: 'boolean',
-        default: true
+        default: config.generateWorkspace !== false
       },
       headless: {
         type: 'boolean',

--- a/packages/galata/jest-env.js
+++ b/packages/galata/jest-env.js
@@ -247,7 +247,9 @@ class TestEnvironment extends NodeEnvironment {
       _createNewPage: this.createNewPage.bind(this),
       _reloadPage: this.reloadPage.bind(this)
     };
-    await this.createNewPage({ generateWorkspace: true });
+    await this.createNewPage({
+      generateWorkspace: sessionInfo.generateWorkspace
+    });
   }
 
   async teardown() {

--- a/packages/galata/jest-setup.js
+++ b/packages/galata/jest-setup.js
@@ -123,6 +123,7 @@ module.exports = async function () {
     referenceDir: config.referenceDir,
     jlabBaseUrl: config.jlabBaseUrl,
     jlabToken: config.jlabToken,
+    generateWorkspace: config.generateWorkspace,
     skipVisualRegression: config.skipVisualRegression === true,
     skipHtmlRegression: config.skipHtmlRegression === true,
     discardMatchedCaptures: config.discardMatchedCaptures !== false,


### PR DESCRIPTION
Make `generateWorkspace` configurable via the CLI to make it easier to reuse `galata` with other projects (#69).