### PR TITLE
increase maxWait in waitForJupyterLabAppObject

### DIFF
--- a/packages/galata/jest-env.js
+++ b/packages/galata/jest-env.js
@@ -75,7 +75,7 @@ class TestEnvironment extends NodeEnvironment {
   /*
    * Wait for window.jupyterlab object to be available or until maxWait
    */
-  async waitForJupyterLabAppObject(maxWait = 5000) {
+  async waitForJupyterLabAppObject(maxWait = 10000) {
     const context = this.global.__TEST_CONTEXT__;
     const checkPeriod = 200;
 


### PR DESCRIPTION
### Description of change 
- Increase the `maxWait` from `5000` to `10000` in `waitForJupyterLabAppObject`
- Reason: We are running into issues where we timeout before `window.jupyterlab` object is available