### PR TITLE
Add archive note to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
     />
 </h1>
 
+
+## Archived
+
+**This project is archived. Development is now happening in https://github.com/jupyterlab/jupyterlab**.
+
+---
+
 Galata is a JupyterLab UI Testing Framework that provides:
 - **[Rich High Level API](packages/galata/src/galata.ts)** to control and inspect JupyterLab UI programmatically
 - **Testing Tools** for capture, comparison and report generation


### PR DESCRIPTION
Communicate development is now happening in the core jupyterlab repo, as mentioned in #81 