### PR TITLE
adding maxWait command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ Notes:
 
     *Default*: `false`
 
+- **--max-wait**: Maximum time (in ms) to wait for JupyterLab to load
+
+    *Default*: `5000`
+
 - **--help**: Show usage information
 
     Shows usage information with list of all command-line options. Skips test execution.

--- a/packages/galata/bin/cli.js
+++ b/packages/galata/bin/cli.js
@@ -59,6 +59,7 @@ const cli = meow(
       --image-match-threshold     image matching threshold
       --slow-mo                   slow down UI operations by the specified ms
       --theme                     JupyterLab Theme to set [light / JupyterLab Light, dark / JupyterLab Dark, installed theme name]
+      --max-wait                  maximum time (in ms) to wait for for JupyterLab to load (window.jupyterlab object available)
 
     Other options:
       --launch-result-server      launch result file server for a test
@@ -193,6 +194,10 @@ const cli = meow(
       theme: {
         type: 'string',
         default: config.theme || ''
+      },
+      maxWait: {
+        type: 'number',
+        default: config.maxWait || 5000
       }
     }
   }

--- a/packages/galata/jest-env.js
+++ b/packages/galata/jest-env.js
@@ -103,7 +103,8 @@ class TestEnvironment extends NodeEnvironment {
       await context.page.goto(context.jlabUrl, {
         waitUntil: 'domcontentloaded'
       });
-      await this.waitForJupyterLabAppObject();
+      const maxWait = config.maxWait ? config.maxWait : 5000;
+      await this.waitForJupyterLabAppObject(maxWait);
     } catch (error) {
       await logAndExit(
         'error',

--- a/packages/galata/util.js
+++ b/packages/galata/util.js
@@ -15,7 +15,8 @@ const configKeys = {
     'testId',
     'testOutputDir',
     'referenceDir',
-    'theme'
+    'theme',
+    'maxWait'
   ]),
   boolean: new Set([
     'headless',


### PR DESCRIPTION
# Description of change

This PR introduces a new optional command line flag `max-wait` to support customizable timeouts (implementing suggestion made in https://github.com/jupyterlab/galata/pull/80 to handle use case of an instance of JupyterLab taking longer than the current 5000 ms default before the `window.jupyterlab` object is available)